### PR TITLE
Fix cursor visibility in light theme and update cosmic-latte configuration

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -10,7 +10,9 @@
       "Bash(nvim:*)",
       "Bash(git checkout:*)",
       "Bash(mkdir:*)",
-      "Bash(cp:*)"
+      "Bash(cp:*)",
+      "Bash(rm:*)",
+      "Bash(ls:*)"
     ],
     "deny": []
   }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -12,7 +12,8 @@
       "Bash(mkdir:*)",
       "Bash(cp:*)",
       "Bash(rm:*)",
-      "Bash(ls:*)"
+      "Bash(ls:*)",
+      "Bash(git remote set-url:*)"
     ],
     "deny": []
   }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -7,7 +7,10 @@
       "Bash(git commit:*)",
       "Bash(git push:*)",
       "Bash(find:*)",
-      "Bash(nvim:*)"
+      "Bash(nvim:*)",
+      "Bash(git checkout:*)",
+      "Bash(mkdir:*)",
+      "Bash(cp:*)"
     ],
     "deny": []
   }

--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,9 @@ lazy-lock.json
 # macOS
 .DS_Store
 
+# Claude configuration
+.claude/
+CLAUDE.md
+
 # Cosmic Latte theme (separate repo)
 cosmic-latte.nvim/

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,3 @@ lazy-lock.json
 # Claude configuration
 .claude/
 CLAUDE.md
-
-# Cosmic Latte theme (separate repo)
-cosmic-latte.nvim/

--- a/lua/plugins/cosmic-latte.lua
+++ b/lua/plugins/cosmic-latte.lua
@@ -5,20 +5,62 @@ return {
     lazy = false,
     config = function()
       vim.opt.termguicolors = true
-      -- Set default variant to dim (Cosmic Mocha Latte)
-      vim.g.cosmic_latte_variant = "dim"
+      -- Set default variant to light (Cosmic Latte)
+      vim.g.cosmic_latte_variant = "light"
       -- Load the colorscheme
       vim.cmd("colorscheme cosmic-latte")
+      
+      -- Set cursor colors for better contrast in light theme
+      vim.api.nvim_create_autocmd("ColorScheme", {
+        pattern = "cosmic-latte",
+        callback = function()
+          if vim.g.cosmic_latte_variant == "light" then
+            -- Black cursor for light theme with white text
+            vim.api.nvim_set_hl(0, "Cursor", { bg = "#000000", fg = "#ffffff" })
+            vim.api.nvim_set_hl(0, "lCursor", { bg = "#000000", fg = "#ffffff" })
+            vim.api.nvim_set_hl(0, "CursorIM", { bg = "#000000", fg = "#ffffff" })
+            vim.api.nvim_set_hl(0, "TermCursor", { bg = "#000000", fg = "#ffffff" })
+            -- Override guicursor to ensure our cursor colors are used
+            vim.opt.guicursor = "n-v-c:block-Cursor/lCursor,i-ci-ve:ver25-Cursor/lCursor,r-cr:hor20-Cursor/lCursor,o:hor50-Cursor/lCursor"
+          else
+            -- White cursor for dim theme with black text
+            vim.api.nvim_set_hl(0, "Cursor", { bg = "#ffffff", fg = "#000000" })
+            vim.api.nvim_set_hl(0, "lCursor", { bg = "#ffffff", fg = "#000000" })
+            vim.api.nvim_set_hl(0, "CursorIM", { bg = "#ffffff", fg = "#000000" })
+          end
+        end
+      })
+      
+      -- Apply cursor colors immediately for current variant
+      if vim.g.cosmic_latte_variant == "light" then
+        vim.api.nvim_set_hl(0, "Cursor", { bg = "#000000", fg = "#ffffff" })
+        vim.api.nvim_set_hl(0, "lCursor", { bg = "#000000", fg = "#ffffff" })
+        vim.api.nvim_set_hl(0, "CursorIM", { bg = "#000000", fg = "#ffffff" })
+        vim.api.nvim_set_hl(0, "TermCursor", { bg = "#000000", fg = "#ffffff" })
+        -- Override guicursor to ensure our cursor colors are used
+        vim.opt.guicursor = "n-v-c:block-Cursor/lCursor,i-ci-ve:ver25-Cursor/lCursor,r-cr:hor20-Cursor/lCursor,o:hor50-Cursor/lCursor"
+      end
       
       -- Quick hotkeys for theme switching
       vim.keymap.set("n", "<leader>tl", function()
         vim.cmd("CosmicLatte")
         vim.notify("Switched to Light theme (Cosmic Latte)", vim.log.levels.INFO)
+        -- Apply light theme cursor colors
+        vim.api.nvim_set_hl(0, "Cursor", { bg = "#000000", fg = "#ffffff" })
+        vim.api.nvim_set_hl(0, "lCursor", { bg = "#000000", fg = "#ffffff" })
+        vim.api.nvim_set_hl(0, "CursorIM", { bg = "#000000", fg = "#ffffff" })
+        vim.api.nvim_set_hl(0, "TermCursor", { bg = "#000000", fg = "#ffffff" })
+        -- Override guicursor to ensure our cursor colors are used
+        vim.opt.guicursor = "n-v-c:block-Cursor/lCursor,i-ci-ve:ver25-Cursor/lCursor,r-cr:hor20-Cursor/lCursor,o:hor50-Cursor/lCursor"
       end, { desc = "Switch to light theme" })
       
       vim.keymap.set("n", "<leader>td", function()
         vim.cmd("CosmicLatteDim") 
         vim.notify("Switched to Dim theme (Cosmic Mocha Latte)", vim.log.levels.INFO)
+        -- Apply dim theme cursor colors
+        vim.api.nvim_set_hl(0, "Cursor", { bg = "#ffffff", fg = "#000000" })
+        vim.api.nvim_set_hl(0, "lCursor", { bg = "#ffffff", fg = "#000000" })
+        vim.api.nvim_set_hl(0, "CursorIM", { bg = "#ffffff", fg = "#000000" })
       end, { desc = "Switch to dim theme" })
       
       vim.keymap.set("n", "<leader>tc", function()
@@ -26,9 +68,20 @@ return {
         if vim.g.colors_name == "cosmic-latte-dim" then
           vim.cmd("CosmicLatte")
           vim.notify("Switched to Light theme (Cosmic Latte)", vim.log.levels.INFO)
+          -- Apply light theme cursor colors
+          vim.api.nvim_set_hl(0, "Cursor", { bg = "#000000", fg = "#ffffff" })
+          vim.api.nvim_set_hl(0, "lCursor", { bg = "#000000", fg = "#ffffff" })
+          vim.api.nvim_set_hl(0, "CursorIM", { bg = "#000000", fg = "#ffffff" })
+          vim.api.nvim_set_hl(0, "TermCursor", { bg = "#000000", fg = "#ffffff" })
+          -- Override guicursor to ensure our cursor colors are used
+          vim.opt.guicursor = "n-v-c:block-Cursor/lCursor,i-ci-ve:ver25-Cursor/lCursor,r-cr:hor20-Cursor/lCursor,o:hor50-Cursor/lCursor"
         else
           vim.cmd("CosmicLatteDim")
           vim.notify("Switched to Dim theme (Cosmic Mocha Latte)", vim.log.levels.INFO)
+          -- Apply dim theme cursor colors
+          vim.api.nvim_set_hl(0, "Cursor", { bg = "#ffffff", fg = "#000000" })
+          vim.api.nvim_set_hl(0, "lCursor", { bg = "#ffffff", fg = "#000000" })
+          vim.api.nvim_set_hl(0, "CursorIM", { bg = "#ffffff", fg = "#000000" })
         end
       end, { desc = "Toggle between light/dim themes" })
     end,

--- a/lua/plugins/cosmic-latte.lua
+++ b/lua/plugins/cosmic-latte.lua
@@ -1,43 +1,34 @@
 return {
   {
-    "cosmic-latte.nvim",
-    dir = vim.fn.stdpath("config") .. "/cosmic-latte.nvim",
-    name = "cosmic-latte",
+    "lightnolimit/cosmic-latte-theme-nvim",
     priority = 1000,
     lazy = false,
     config = function()
       vim.opt.termguicolors = true
-      -- Default to dim theme, use :colorscheme cosmic-latte for light version
-      vim.cmd("colorscheme cosmic-latte-dim")
-      
-      -- Add commands to switch between themes
-      vim.api.nvim_create_user_command("CosmicLatteDim", function()
-        vim.cmd("colorscheme cosmic-latte-dim")
-      end, { desc = "Switch to Cosmic Latte Dim theme" })
-      
-      vim.api.nvim_create_user_command("CosmicLatteLight", function()
-        vim.cmd("colorscheme cosmic-latte")
-      end, { desc = "Switch to Cosmic Latte Light theme" })
+      -- Set default variant to dim (Cosmic Mocha Latte)
+      vim.g.cosmic_latte_variant = "dim"
+      -- Load the colorscheme
+      vim.cmd("colorscheme cosmic-latte")
       
       -- Quick hotkeys for theme switching
       vim.keymap.set("n", "<leader>tl", function()
-        vim.cmd("colorscheme cosmic-latte")
+        vim.cmd("CosmicLatteLight")
         vim.notify("Switched to Light theme", vim.log.levels.INFO)
       end, { desc = "Switch to light theme" })
       
       vim.keymap.set("n", "<leader>td", function()
-        vim.cmd("colorscheme cosmic-latte-dim") 
-        vim.notify("Switched to Dim theme", vim.log.levels.INFO)
+        vim.cmd("CosmicLatteDim") 
+        vim.notify("Switched to Dim theme (Cosmic Mocha Latte)", vim.log.levels.INFO)
       end, { desc = "Switch to dim theme" })
       
       vim.keymap.set("n", "<leader>tc", function()
         -- Toggle between light and dim
         if vim.g.colors_name == "cosmic-latte-dim" then
-          vim.cmd("colorscheme cosmic-latte")
+          vim.cmd("CosmicLatteLight")
           vim.notify("Switched to Light theme", vim.log.levels.INFO)
         else
-          vim.cmd("colorscheme cosmic-latte-dim")
-          vim.notify("Switched to Dim theme", vim.log.levels.INFO)
+          vim.cmd("CosmicLatteDim")
+          vim.notify("Switched to Dim theme (Cosmic Mocha Latte)", vim.log.levels.INFO)
         end
       end, { desc = "Toggle between light/dim themes" })
     end,

--- a/lua/plugins/cosmic-latte.lua
+++ b/lua/plugins/cosmic-latte.lua
@@ -13,7 +13,7 @@ return {
       -- Quick hotkeys for theme switching
       vim.keymap.set("n", "<leader>tl", function()
         vim.cmd("CosmicLatteLight")
-        vim.notify("Switched to Light theme", vim.log.levels.INFO)
+        vim.notify("Switched to Light theme (Cosmic Latte)", vim.log.levels.INFO)
       end, { desc = "Switch to light theme" })
       
       vim.keymap.set("n", "<leader>td", function()
@@ -25,7 +25,7 @@ return {
         -- Toggle between light and dim
         if vim.g.colors_name == "cosmic-latte-dim" then
           vim.cmd("CosmicLatteLight")
-          vim.notify("Switched to Light theme", vim.log.levels.INFO)
+          vim.notify("Switched to Light theme (Cosmic Latte)", vim.log.levels.INFO)
         else
           vim.cmd("CosmicLatteDim")
           vim.notify("Switched to Dim theme (Cosmic Mocha Latte)", vim.log.levels.INFO)

--- a/lua/plugins/cosmic-latte.lua
+++ b/lua/plugins/cosmic-latte.lua
@@ -12,7 +12,7 @@ return {
       
       -- Quick hotkeys for theme switching
       vim.keymap.set("n", "<leader>tl", function()
-        vim.cmd("CosmicLatteLight")
+        vim.cmd("CosmicLatte")
         vim.notify("Switched to Light theme (Cosmic Latte)", vim.log.levels.INFO)
       end, { desc = "Switch to light theme" })
       
@@ -24,7 +24,7 @@ return {
       vim.keymap.set("n", "<leader>tc", function()
         -- Toggle between light and dim
         if vim.g.colors_name == "cosmic-latte-dim" then
-          vim.cmd("CosmicLatteLight")
+          vim.cmd("CosmicLatte")
           vim.notify("Switched to Light theme (Cosmic Latte)", vim.log.levels.INFO)
         else
           vim.cmd("CosmicLatteDim")


### PR DESCRIPTION
## Summary
- Fixed cursor visibility issue in light theme by overriding guicursor option
- Updated cosmic-latte plugin configuration to use external repository
- Set light theme as default variant

## Changes
- Added guicursor override to ensure black cursor is visible on light backgrounds
- Applied cursor settings in ColorScheme autocmd and theme switching functions
- Added TermCursor highlight group for terminal cursor consistency
- Updated theme switching commands to use simplified names (CosmicLatte/CosmicLatteDim)

## Test plan
- [x] Test cursor visibility in light theme
- [x] Test cursor visibility in dim theme
- [x] Test theme switching commands
- [x] Verify cursor remains visible in insert mode
- [x] Verify cursor is visible in terminal windows